### PR TITLE
Improve web search dataset

### DIFF
--- a/server.js
+++ b/server.js
@@ -32,11 +32,12 @@ function createCustomEntity(keyword) {
 
 function getComponentListEntity(fetchNew) {
 	fetchComponents(fetchNew || false).then(function (list) {
-		console.log('Finished fetching data from GitHub', '' + new Date());
 
 		registry = list.filter(function (el) {
 			return el != null;
 		});
+
+		console.log('Finished fetching '+list.length+' projects from GitHub', '' + new Date());
 
 		entity = createEntity(registry);
 	}).fail(function (err) {
@@ -97,4 +98,4 @@ setInterval(function () {
 	process.exit(0);
 }, 1000 * 60 * 60 * 24);
 
-console.log('Server running on port ' + HTTP_PORT);
+console.log('Server running on port ' + HTTP_PORT, '' + new Date());


### PR DESCRIPTION
This patch cleans up the search data by doing two things.

* Follows GitHub redirects to moved packages, currently any renamd package is dropped from the search data.
* Drops any project from the search data that doesn't contain a bower.json file.

Due to the API limits I've only been able to test this on the first 4,000 records in the Bower DB, if you can give me a better key I'm happy to test the full dataset.

In the first 4,000 records this patch results in the following:

240 packages added back into the data.
270 packages dropped for not being bower projects.
171 packages confirmed as really no longer being on GitHub.

Scaling those numbers up to the full dataset give an estimate of 1,657 missing projects added into the search results and 1,863 non-Bower projects removed from the search results.

Fixes:
#14
#20 
https://github.com/bower/search/issues/57
https://github.com/bower/search/issues/36

